### PR TITLE
Updated descriptions for tool descriptors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,7 +258,7 @@ celerybeat.pid
 .env
 .venv
 env/
-venv/
+*venv/
 ENV/
 env.bak/
 venv.bak/

--- a/descriptors/afni/3dDegreeCentrality.json
+++ b/descriptors/afni/3dDegreeCentrality.json
@@ -1,8 +1,9 @@
 {
   "name": "3dDegreeCentrality",
   "command-line": "3dDegreeCentrality [IN_FILE] [AUTOCLIP] [AUTOMASK] [MASK] [ONED_FILE] [OUT_FILE] [POLORT] [SPARSITY] [THRESH]",
-  "author": "Nipype (interface)",
-  "description": "3dDegreeCentrality, as implemented in Nipype (module: nipype.interfaces.afni.preprocess, interface: DegreeCentrality).\nPerforms degree centrality on a dataset using a given maskfile via 3dDegreeCentrality\nFor complete details, see the `3dDegreeCentrality Documentation. <https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dDegreeCentrality.html>`_",
+  "author": "RWCox @ AFNI",
+  "description": "Computes voxelwise weighted and binary degree centrality and stores the result in a new 3D bucket dataset as floats to preserve their values. Degree centrality reflects the strength and extent of the correlation of a voxel with every other voxel in the brain. ",
+  "url": "https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dDegreeCentrality.html",
   "inputs": [
     {
       "id": "autoclip",
@@ -102,7 +103,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/afni/3dDespike.json
+++ b/descriptors/afni/3dDespike.json
@@ -1,8 +1,9 @@
 {
   "name": "3dDespike",
   "command-line": "3dDespike [IN_FILE] [OUT_FILE]",
-  "author": "Nipype (interface)",
-  "description": "AFNI 3dDespike, as implemented in Nipype (module: nipype.interfaces.afni.preprocess, interface: Despike).\nRemoves 'spikes' from the 3D+time input dataset\nFor complete details, see the `3dDespike Documentation. <https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dDespike.html>`_",
+  "author": "AFNI",
+  "description": "Removes 'spikes' from the 3D+time input dataset and writes a new dataset with the spike values replaced by something more pleasing to the eye.",
+  "url": "https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dDespike.html",
   "inputs": [
     {
       "id": "in_file",
@@ -31,7 +32,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/afni/3dSkullStrip.json
+++ b/descriptors/afni/3dSkullStrip.json
@@ -1,8 +1,9 @@
 {
   "name": "3dSkullStrip",
   "command-line": "3dSkullStrip [IN_FILE] [ARGS] [ENVIRON] [NUM_THREADS] [OUT_FILE] [OUTPUTTYPE]",
-  "author": "Nipype (interface)",
-  "description": "SkullStrip, as implemented in Nipype (module: nipype.interfaces.afni, interface: SkullStrip).\nA program to extract the brain from surrounding tissue from MRI T1-weighted images. TODO Add optional arguments.\nFor complete details, see the `3dSkullStrip Documentation. <https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dSkullStrip.html>`_",
+  "author": "AFNI",
+  "description": "A program to extract the brain from surrounding tissue from MRI T1-weighted images.",
+  "url": "https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dSkullStrip.html",
   "inputs": [
     {
       "id": "in_file",
@@ -58,7 +59,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/afni/3dTcorrelate.json
+++ b/descriptors/afni/3dTcorrelate.json
@@ -2,7 +2,8 @@
   "name": "3dTCorrelate",
   "command-line": "3dTCorrelate [XSET] [YSET] [PEARSON] [SPEARMAN] [QUADRANT] [KTAUB] [COVARIANCE] [PARTIAL] [YCOEF] [FISHER] [POLORT] [ORT] [AUTOCLIP] [AUTOMASK] [ZCENSOR] [PREFIX]",
   "author": "RWCox @ AFNI",
-  "description": "3dTCorrelate. Computes the correlation coefficient between corresponding voxel time series in two input 3D+time datasets 'xset' and 'yset'. For complete details, see the `3dTcorrelate Documentation. <https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dTcorrelate.html>",
+  "description": "3dTCorrelate. Computes the correlation coefficient between corresponding voxel time series in two input 3D+time datasets 'xset' and 'yset'.",
+  "url": "https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dTcorrelate.html",
   "inputs": [
     {
       "id": "pearson",
@@ -188,7 +189,6 @@
   },
   "tags": {
     "domain": "neuroinformatics",
-    "source": "nipype-interface",
     "package": "afni"
   }
 }

--- a/descriptors/afni/3dTproject.json
+++ b/descriptors/afni/3dTproject.json
@@ -1,8 +1,9 @@
 {
   "name": "3dTproject",
   "command-line": "3dTproject [IN_FILE] [OUT_FILE] [TR] [AUTOMASK] [BANDPASS] [BLUR] [CENMODE] [CENSOR] [CENSORTR] [CONCAT] [DSORT] [MASK] [NOBLOCK] [NORM] [ORT] [POLORT] [STOPBAND]",
-  "author": "Nipype (interface)",
-  "description": "3dTproject, as implemented in Nipype (module: nipype.interfaces.afni, interface: TProject).\n\nThis program projects (detrends) out various 'nuisance' time series from each voxel in the input dataset. Note that all the projections are done via linear regression, including the frequency-based options such as ``-passband``. In this way, you can bandpass time-censored data, and at the same time, remove other time series of no interest (e.g., physiological estimates, motion parameters). Shifts voxel time series from input so that separate slices are aligned to the same temporal origin.",
+  "author": "RWCox @ AFNI",
+  "description": "This program projects (detrends) out various 'nuisance' time series from each voxel in the input dataset.  Note that all the projections are done via linear regression, including the frequency-based options such as '-passband'.  In this way, you can bandpass time-censored data, and at the same time, remove other time series of no interest (e.g., physiological estimates, motion parameters).",
+  "url": "https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dTproject.html",
   "inputs": [
     {
       "id": "TR",
@@ -185,7 +186,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/afni/3dcalc.json
+++ b/descriptors/afni/3dcalc.json
@@ -1,8 +1,9 @@
 {
   "name": "3dcalc",
   "command-line": "3dcalc [IN_FILE_A] [IN_FILE_B] [IN_FILE_C] -expr \"[EXPR]\" [OTHER] [OUT_FILE] [OVERWRITE] [SINGLE_IDX] [START_IDX] [STOP_IDX]",
-  "author": "Nipype (interface)",
-  "description": "3dcalc, as implemented in Nipype (module: nipype.interfaces.afni.utils, interface: Calc).\nThis program does voxel-by-voxel arithmetic on 3D datasets.\nFor complete details, see the `3dcalc Documentation. <https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dcalc.html>`_",
+  "author": "RWCox @ AFNI",
+  "description": "AFNI's calculator program.",
+  "url": "https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dcalc.html",
   "inputs": [
     {
       "id": "expr",
@@ -104,7 +105,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/c3/c3d_affine_tool.json
+++ b/descriptors/c3/c3d_affine_tool.json
@@ -1,8 +1,8 @@
 {
   "name": "C3dAffineTool",
   "command-line": "c3d_affine_tool [REFERENCE_FILE] [SOURCE_FILE] [TRANSFORM_FILE] [SFORM_FILE] [OUT_MATFILE] [FSL2RAS] [RAS2FSL] [INV] [DET] [MULT] [SQRT] [ITK_TRANSFORM] [OUT_ITK_TRANSFORM] [IRTK_TRANSFORM] [OUT_IRTK_TRANSFORM] [INFO] [INFO_FULL]",
-  "author": "Nipype (interface)",
-  "description": "C3dAffineTool, as implemented in Nipype (module: nipype.interfaces.c3, interface: C3dAffineTool).\nConverts fsl-style Affine registration into ANTS compatible itk format.'",
+  "author": "ITK-Snap Team",
+  "description": "RAS affine transform tool",
   "inputs": [
     {
       "id": "reference_file",
@@ -187,7 +187,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/freesurfer/apply_vol_transform.json
+++ b/descriptors/freesurfer/apply_vol_transform.json
@@ -1,8 +1,9 @@
 {
   "name": "ApplyVolTransform",
   "command-line": "mri_vol2vol [FS_TARGET] [FSL_REG_FILE] [INTERP] [INVERSE] [INVERT_MORPH] [LTA_FILE] [LTA_INV_FILE] [M3Z_FILE] [MNI_152_REG] [NO_DEF_M3Z_PATH] [NO_RESAMPLE] [REG_FILE] [REG_HEADER] [SOURCE_FILE] [SUBJECT] [SUBJECTS_DIR] [TAL] [TAL_RESOLUTION] [TARGET_FILE] [TRANSFORMED_FILE] [XFM_REG_FILE]",
-  "author": "Nipype (interface)",
-  "description": "ApplyVolTransform, as implemented in Nipype (module: nipype.interfaces.freesurfer.preprocess, interface: ApplyVolTransform).\nUse FreeSurfer mri_vol2vol to apply a transform.",
+  "author": "Members of the Laboratories for Computational Neuroimaging (LCN) at the Athinoula A. Martinos Center for Biomedical Imaging",
+  "description": "Resamples a volume into another field-of-view using varous types of matrices (FreeSurfer, FSL, SPM, and MNI).",
+  "url": "https://surfer.nmr.mgh.harvard.edu/fswiki/mri_vol2vol",
   "inputs": [
     {
       "id": "fs_target",
@@ -257,7 +258,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/freesurfer/mri_binarize.json
+++ b/descriptors/freesurfer/mri_binarize.json
@@ -1,8 +1,9 @@
 {
   "name": "mri binarize",
   "command-line": "mri_binarize [ABS] [BIN_COL_NUM] [BIN_VAL] [BIN_VAL_NOT] [BINARY_FILE] [COUNT_FILE] [DILATE] [ERODE] [ERODE2D] [FRAME_NO] [IN_FILE] [INVERT] [MASK_FILE] [MASK_THRESH] [MATCH] [MAX] [MERGE_FILE] [MIN] [OUT_TYPE] [RMAX] [RMIN] [SUBJECTS_DIR] [VENTRICLES] [WM] [WM_VEN_CSF] [ZERO_EDGES] [ZERO_SLICE_EDGE]",
-  "author": "Nipype (interface)",
-  "description": "mri_binarize, as implemented in Nipype (module: nipype.interfaces.freesurfer.model, interface: mri_binarize).\nUse FreeSurfer mri_binarize to threshold an input volume",
+  "author": "Members of the Laboratories for Computational Neuroimaging (LCN) at the Athinoula A. Martinos Center for Biomedical Imaging",
+  "description": "Program to binarize a volume (or volume-encoded surface file). Can also be used to merge with other binarizations. Binarization can be done based on threshold or on matched values.",
+  "url": "https://surfer.nmr.mgh.harvard.edu/fswiki/mri_binarize",
   "inputs": [
     {
       "id": "abs",
@@ -319,7 +320,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/freesurfer/recon_all.json
+++ b/descriptors/freesurfer/recon_all.json
@@ -1,8 +1,9 @@
 {
   "name": "ReconAll",
   "command-line": "ReconAll [DIRECTIVE] [FLAIR_FILE] [T1_FILES] [T2_FILE] [BIG_VENTRICLES] [BRAINSTEM] [EXPERT] [FLAGS] [HEMI] [HIPPOCAMPAL_SUBFIELDS_T1] [HIPPOCAMPAL_SUBFIELDS_T2] [HIRES] [MPRAGE] [OPENMP] [PARALLEL] [SUBJECT_ID] [SUBJECTS_DIR] [TALAIRACH] [USE_FLAIR] [USE_T2] [XOPTS]",
-  "author": "Nipype (interface)",
-  "description": "ReconAll, as implemented in Nipype (module: nipype.interfaces.freesurfer.preprocess, interface: ReconAll).\nUses recon-all to generate surfaces and parcellations of structural data from anatomical images of a subject.",
+  "author": "Members of the Laboratories for Computational Neuroimaging (LCN) at the Athinoula A. Martinos Center for Biomedical Imaging",
+  "description": "Performs all, or any part of, the FreeSurfer cortical reconstruction process.",
+  "url": "https://surfer.nmr.mgh.harvard.edu/fswiki/recon-all",
   "inputs": [
     {
       "id": "FLAIR_file",
@@ -248,7 +249,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/fsl/apply_warp.json
+++ b/descriptors/fsl/apply_warp.json
@@ -1,8 +1,8 @@
 {
   "name": "applywarp",
   "command-line": "applywarp [INTERP] [IN_FILE] [REF_FILE] [OUT_FILE] [RELWARP] [ABSWARP] [ARGS] [DATATYPE] [ENVIRON] [FIELD_FILE] [MASK_FILE] [OUTPUT_TYPE] [POSTMAT] [PREMAT] [SUPERLEVEL] [SUPERSAMPLE]",
-  "author": "Nipype (interface)",
-  "description": "applywarp, as implemented in Nipype (module: nipype.interfaces.fsl, interface: ApplyWarp).\nFSL's applywarp wrapper to apply the results of a FNIRT registration",
+  "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+  "description": "Apply warps estimated by FNIRT (or some other software) to some image.",
   "inputs": [
     {
       "id": "abswarp",
@@ -185,7 +185,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/fsl/bet.json
+++ b/descriptors/fsl/bet.json
@@ -3,6 +3,8 @@
   "name": "bet",
   "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
   "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_bet.json",
+  "description": "Automated brain extraction tool for FSL",
+  "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/BET",
   "command-line": "bet [INPUT_FILE] [MASK] [FRACTIONAL_INTENSITY] [VERTICAL_GRADIENT] [CENTER_OF_GRAVITY] [OVERLAY_FLAG] [BINARY_MASK_FLAG] [APPROX_SKULL_FLAG] [NO_SEG_OUTPUT_FLAG] [VTK_VIEW_FLAG] [HEAD_RADIUS] [THRESHOLDING_FLAG] [ROBUST_ITERS_FLAG] [RES_OPTIC_CLEANUP_FLAG] [REDUCE_BIAS_FLAG] [SLICE_PADDING_FLAG] [MASK_WHOLE_SET_FLAG] [ADD_SURFACES_FLAG] [ADD_SURFACES_T2] [VERBOSE_FLAG] [DEBUG_FLAG]",
   "container-image": {
     "image": "mcin/docker-fsl:latest",
@@ -376,6 +378,5 @@
         ]
       }
     }
-  ],
-  "description": "Automated brain extraction tool for FSL"
+  ]
 }

--- a/descriptors/fsl/convert_xfm.json
+++ b/descriptors/fsl/convert_xfm.json
@@ -1,8 +1,9 @@
 {
   "name": "convert_xfm",
   "command-line": "convert_xfm [IN_FILE] [INVERT_XFM] [CONCAT_XFM] [FIX_SCALE_SKEW] [OUT_FILE]",
-  "author": "FMRIB",
-  "description": "convert_xfm, as implemented in Nipype (module: nipype.interfaces.fsl.utils, interface: ConvertXFM). Use the FSL utility convert_xfm to modify FLIRT transformation matrices.",
+  "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+  "description": "convert_xfm is a utility that is used to convert between different transformation file formats. It can read and write ascii 4x4 matrices. In addition, it can be used to concatenate two transforms (using -concat with the second transform) or to find the inverse transformation (using -inverse).",
+  "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FLIRT/UserGuide#convert_xfm",
   "inputs": [
     {
       "id": "concat_xfm",
@@ -74,7 +75,6 @@
   },
   "tags": {
     "domain": "neuroinformatics",
-    "source": "nipype-interface",
     "package": "fsl"
   }
 }

--- a/descriptors/fsl/epi_reg.json
+++ b/descriptors/fsl/epi_reg.json
@@ -1,8 +1,9 @@
 {
   "name": "epi_reg",
   "command-line": "epi_reg [EPI] [T1_HEAD] [T1_BRAIN] [OUT_BASE_NAME] [ECHOSPACING] [FMAP] [FMAPMAG] [FMAPMAGBRAIN] [NO_CLEAN] [NO_FMAPREG] [PEDIR] [WEIGHT_IMAGE] [WMSEG]",
-  "author": "FMRIB",
-  "description": "epi_reg, as implemented in Nipype (module: nipype.interfaces.fsl, interface: EpiReg). Runs FSL epi_reg script for simultaneous coregistration and fieldmap unwarping.",
+  "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+  "description": "Runs FSL epi_reg script for simultaneous coregistration and fieldmap unwarping.",
+  "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FLIRT/UserGuide#epi_reg",
   "inputs": [
     {
       "id": "echospacing",
@@ -242,7 +243,6 @@
   },
   "tags": {
     "domain": "neuroinformatics",
-    "source": "nipype-interface",
     "package": "fsl"
   }
 }

--- a/descriptors/fsl/fast.json
+++ b/descriptors/fsl/fast.json
@@ -1,8 +1,9 @@
 {
   "name": "FAST",
   "command-line": "FAST [NUMBER_CLASSES] [BIAS_ITERS] [BIAS_LOWPASS] [IMG_TYPE] [INIT_SEG_SMOOTH] [SEGMENTS] [INIT_TRANSFORM] [OTHER_PRIORS] [OUTPUT_BIASFIELD] [OUTPUT_BIASCORRECTED] [NO_BIAS] [CHANNELS] [OUT_BASENAME] [USE_PRIORS] [NO_PVE] [SEGMENT_ITERS] [MIXEL_SMOOTH] [HYPER] [VERBOSE] [MANUAL_SEG] [ITERS_AFTERBIAS] [PROBABILITY_MAPS] [IN_FILES]",
-  "author": "Nipype (interface)",
-  "description": "FAST, as implemented in Nipype (module: nipype.interfaces.fsl, interface: FAST).\nFSL FAST wrapper for segmentation and bias correction\nFor complete details, see the `FAST Documentation. <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FAST>`_",
+  "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+  "description": "FAST (FMRIB's Automated Segmentation Tool) segments a 3D image of the brain into different tissue types (Grey Matter, White Matter, CSF, etc.), whilst also correcting for spatial intensity variations (also known as bias field or RF inhomogeneities). The underlying method is based on a hidden Markov random field model and an associated Expectation-Maximization algorithm. The whole process is fully automated and can also produce a bias field-corrected input image and a probabilistic and/or partial volume tissue segmentation. It is robust and reliable, compared to most finite mixture model-based methods, which are sensitive to noise.",
+  "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FAST",
   "inputs": [
     {
       "name": "Number classes",
@@ -316,7 +317,6 @@
   },
   "tags": {
     "domain": "neuroinformatics",
-    "source": "nipype-interface",
     "package": "fsl"
   }
 }

--- a/descriptors/fsl/flirt.json
+++ b/descriptors/fsl/flirt.json
@@ -1,8 +1,9 @@
 {
   "name": "FLIRT",
   "command-line": "FLIRT [IN_FILE] [REFERENCE] [OUT_FILE] [OUT_MATRIX_FILE] [ANGLE_REP] [APPLY_ISOXFM] [APPLY_XFM] [BBRSLOPE] [BBRTYPE] [BGVALUE] [BINS] [COARSE_SEARCH] [COST] [COST_FUNC] [DATATYPE] [DISPLAY_INIT] [DOF] [ECHOSPACING] [FIELDMAP] [FIELDMAPMASK] [FINE_SEARCH] [FORCE_SCALING] [IN_MATRIX_FILE] [IN_WEIGHT] [INTERP] [MIN_SAMPLING] [NO_CLAMP] [NO_RESAMPLE] [NO_RESAMPLE_BLUR] [NO_SEARCH] [PADDING_SIZE] [PEDIR] [REF_WEIGHT] [RIGID2D] [SCHEDULE] [SEARCHR_X] [SEARCHR_Y] [SEARCHR_Z] [SINC_WIDTH] [SINC_WINDOW] [USES_QFORM] [VERBOSE] [WM_SEG] [WMCOORDS] [WMNORMS]",
-  "author": "Nipype (interface)",
-  "description": "FLIRT, as implemented in Nipype (module: nipype.interfaces.fsl, interface: FLIRT).\nFSL FLIRT wrapper for coregistration\nFor complete details, see the `FLIRT Documentation. <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FLIRT>`_\nTo print out the command line help, use: fsl.FLIRT().inputs_help()",
+  "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+  "description": "FLIRT (FMRIB's Linear Image Registration Tool) is a fully automated robust and accurate tool for linear (affine) intra- and inter-modal brain image registration.",
+  "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FLIRT",
   "inputs": [
     {
       "id": "angle_rep",
@@ -482,7 +483,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/fsl/fnirt.json
+++ b/descriptors/fsl/fnirt.json
@@ -1,8 +1,9 @@
 {
   "name": "fnirt",
   "command-line": "fnirt [AFFINE_FILE] [CONFIG_FILE] [FIELD_FILE] [FIELDCOEFF_FILE] [IN_FILE] [JACOBIAN_FILE] [LOG_FILE] [MODULATEDREF_FILE] [REF_FILE] [REFMASK_FILE] [WARPED_FILE]",
-  "author": "Nipype (interface)",
-  "description": "FNIRT, as implemented in Nipype (module: nipype.interfaces.fsl, interface: FNIRT).\nFSL FNIRT wrapper for non-linear registration\nFor complete details, see the `FNIRT Documentation. <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FNIRT>`_",
+  "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+  "description": "FSL non-linear registration",
+  "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FNIRT",
   "inputs": [
     {
       "id": "affine_file",
@@ -175,7 +176,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/fsl/mcflirt.json
+++ b/descriptors/fsl/mcflirt.json
@@ -1,8 +1,9 @@
 {
   "name": "MCFLIRT",
   "command-line": "mcflirt [IN_FILE] [BINS] [COST] [DOF] [INIT] [INTERPOLATION] [MEAN_VOL] [OUT_FILE] [REF_FILE] [REF_VOL] [ROTATION] [SAVE_MATS] [SAVE_PLOTS] [SAVE_RMS] [SCALING] [SMOOTH] [STAGES] [STATS_IMGS] [USE_CONTOUR] [USE_GRADIENT]",
-  "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
-  "description": "MCFLIRT, as implemented in Nipype (module: nipype.interfaces.fsl, interface: MCFLIRT).",
+  "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+  "description": "MCFLIRT is an intra-modal motion correction tool designed for use on fMRI time series and based on optimization and registration techniques used in FLIRT, a fully automated robust and accurate tool for linear (affine) inter- and inter-modal brain image registration.",
+  "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/MCFLIRT",
   "inputs": [
     {
       "id": "bins",
@@ -261,8 +262,6 @@
     "index": "index.docker.io"
   },
   "tags": {
-    "domain": ["neuroinformatics", "mri"],
-    "source": "nipype-interface"
-  },
-  "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/preprocess.py"
+    "domain": ["neuroinformatics", "mri"]
+  }
 }

--- a/descriptors/fsl/merge.json
+++ b/descriptors/fsl/merge.json
@@ -1,8 +1,9 @@
 {
   "name": "Merge",
   "command-line": "fslmerge [DIMENSION] [DIMENSION_TR] [MERGED_FILE] [IN_FILES] [TR] [N]",
-  "author": "Nipype (interface)",
-  "description": "Merge, as implemented in Nipype (module: nipype.interfaces.fsl.utils, interface: Merge).\nUse fslmerge to concatenate images\nImages can be concatenated across time, x, y, or z dimensions. Across the time (t) dimension the TR is set by default to 1 sec.\nNote: to set the TR to a different value, specify 't' for dimension and specify the TR value in seconds for the tr input. The dimension will be automatically updated to 'tr'.",
+  "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+  "description": "Concatenate image files into a single output. This concatenation can be in time, or in X, Y or Z. All image dimensions (except for the one being concatenated over) must be the same in all input images. For example, this can be used to take multiple 3D files (eg as output by SPM) and create a single 4D image file.",
+  "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "inputs": [
     {
       "id": "dimension",
@@ -94,7 +95,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/fsl/roi.json
+++ b/descriptors/fsl/roi.json
@@ -1,8 +1,9 @@
 {
   "name": "FSL roi",
   "command-line": "fslroi [IN_FILE] [ROI_FILE] [X_MIN] [X_SIZE] [Y_MIN] [Y_SIZE] [Z_MIN] [Z_SIZE] [T_MIN] [T_SIZE]",
-  "author": "Nipype (interface)",
-  "description": "fslroi, as implemented in Nipype (module: nipype.interfaces.fsl.utils, interface: ExtractROI).\nUses FSL Fslroi command to extract region of interest (ROI) from an image.\nYou can a) take a 3D ROI from a 3D data set (or if it is 4D, the same ROI is taken from each time point and a new 4D data set is created), b) extract just some time points from a 4D data set, or c) control time and space limits to the ROI. Note that the arguments are minimum index and size (not maximum index). So to extract voxels 10 to 12 inclusive you would specify 10 and 3 (not 10 and 12).",
+  "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+  "description": "Extract region of interest (ROI) from an image.",
+  "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "inputs": [
     {
       "id": "in_file",
@@ -109,7 +110,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/fsl/slicer.json
+++ b/descriptors/fsl/slicer.json
@@ -1,8 +1,9 @@
 {
   "name": "Slicer",
   "command-line": "slicer [IN_FILE] [OVERLAY_FILE] [LABEL_SLICES] [COLOUR_MAP] [SCALING] [INTENSITY_RANGE] [THRESHOLD_EDGES] [DITHER_EDGES] [NEAREST_NEIGHBOUR] [SHOW_ORIENTATION] [MARKER] ...slices... [OUTPUT_SINGLE_IMAGE] [OUTPUT_SAGITTAL_SLICE] [OUTPUT_SAGITTAL_SLICE_FNAME] [OUTPUT_AXIAL_SLICE] [OUTPUT_AXIAL_SLICE_FNAME] [OUTPUT_CORONAL_SLICE] [OUTPUT_CORONAL_SLICE_FNAME] [OUTPUT_ALL_AXIAL_SLICES] [OUTPUT_ALL_AXIAL_SLICES_FNAME] [OUTPUT_SAMPLE_AXIAL_SLICES_NUM] [OUTPUT_SAMPLE_AXIAL_SLICES_WIDTH] [OUTPUT_SAMPLE_AXIAL_SLICES_FNAME]",
-  "author": "Nipype (interface)",
-  "description": "Slicer, as implemented in Nipype (module: nipype.interfaces.fsl, interface: Slicer).\nUse FSL's slicer command to output a png image from a volume.",
+  "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+  "description": "the main program which takes in one or two input images and produces as many separate output pictures of slices as are requested. The basic output options (-x, -y and -z) produce single slice pictures. The more advanced options (-a, -A and -S) produce montages of various slices. slicer outputs PPM format pictures",
+  "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Miscvis",
   "inputs": [
     {
       "id": "in_file",
@@ -305,7 +306,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/fsl/smooth_estimate.json
+++ b/descriptors/fsl/smooth_estimate.json
@@ -1,8 +1,8 @@
 {
   "name": "SmoothEstimate",
   "command-line": "smoothest [DOF] [MASK_FILE] [RESIDUAL_FIT_FILE] [ZSTAT_FILE]",
-  "author": "Nipype (interface)",
-  "description": "SmoothEstimate, as implemented in Nipype (module: nipype.interfaces.fsl, interface: SmoothEstimate).\nEstimates the smoothness of an image",
+  "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+  "description": "Estimates the smoothness of an image",
   "inputs": [
     {
       "id": "dof",
@@ -84,7 +84,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/fsl/split.json
+++ b/descriptors/fsl/split.json
@@ -1,8 +1,9 @@
 {
   "name": "Split",
   "command-line": "fslsplit [IN_FILE] out/[OUT_BASE_NAME] [DIMENSION]",
-  "author": "Nipype (interface)",
-  "description": "Split, as implemented in Nipype (module: nipype.interfaces.fsl, interface: Split).\nUses FSL Fslsplit command to separate a volume into images in time, x, y or z dimension.",
+  "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+  "description": "split a 4D file into lots of 3D files (eg for inputting to SPM).",
+  "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "inputs": [
     {
       "id": "in_file",
@@ -49,7 +50,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }

--- a/descriptors/fsl/swap_dimensions.json
+++ b/descriptors/fsl/swap_dimensions.json
@@ -1,8 +1,9 @@
 {
   "name": "SwapDimensions",
   "command-line": "fslswapdim [IN_FILE] [A_CART] [A_RAS] [B_CART] [B_RAS] [C_CART] [C_RAS] [OUT_FILE]",
-  "author": "Nipype (interface)",
-  "description": "SwapDimensions, as implemented in Nipype (module: nipype.interfaces.fsl, interface: SwapDimensions).\nUse fslswapdim to alter the orientation of an image.\nThis interface accepts a three-tuple corresponding to the new orientation. You may either provide dimension ids in the form of (-)x, (-)y, or (-z), or nifti-syle dimension codes (RL, LR, AP, PA, IS, SI).",
+  "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+  "description": "this is an advanced tool that re-orders the data storage to permit changes between axial, sagittal and coronal slicing. When used in this mode the same left-right convention (also called coordinate handedness or radiological/neurological convention) will be maintained as long as no warning is printed.",
+  "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Fslutils",
   "inputs": [
     {
       "id": "in_file",
@@ -123,7 +124,6 @@
     "type": "docker"
   },
   "tags": {
-    "domain": "neuroinformatics",
-    "source": "nipype-interface"
+    "domain": "neuroinformatics"
   }
 }


### PR DESCRIPTION
Updated the descriptions for most (I think maybe all) of the descriptors that have a closed PR from the boutiquesathon + afterwards. Also updated the URL I could find one - most of the URLs point to the documentation of the specific function, can update to point to tool itself.